### PR TITLE
fix: recursive initializer

### DIFF
--- a/projects/ionic-header-parallax/package-lock.json
+++ b/projects/ionic-header-parallax/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "ionic-header-parallax",
-  "version": "2.1.4",
+  "version": "2.2.2",
   "lockfileVersion": 1
 }

--- a/projects/ionic-header-parallax/src/lib/parallax.directive.ts
+++ b/projects/ionic-header-parallax/src/lib/parallax.directive.ts
@@ -39,7 +39,6 @@ export class ParallaxDirective implements AfterViewInit {
         this.initStyles();
         this.initEvents();
       } catch (e) {
-        console.log('parallax needs more time to start - starting recursive launch attempts with delay 100ms');
         this.ngAfterViewInit();
       }
     }, 100);
@@ -95,6 +94,7 @@ export class ParallaxDirective implements AfterViewInit {
     this.scrollContentPaddingTop = window.getComputedStyle(this.scrollContent, null).paddingTop.replace('px', '');
     this.scrollContentPaddingTop = parseFloat(this.scrollContentPaddingTop);
     this.originalToolbarBgColor = window.getComputedStyle(this.toolbarBackground, null).backgroundColor;
+    if (!this.originalToolbarBgColor) { throw new Error('Error: toolbarBackround is null.'); }
 
     // header and title
     this.renderer.setStyle(this.header, 'position', 'relative');

--- a/projects/ionic-header-parallax/src/lib/parallax.directive.ts
+++ b/projects/ionic-header-parallax/src/lib/parallax.directive.ts
@@ -34,9 +34,14 @@ export class ParallaxDirective implements AfterViewInit {
 
   ngAfterViewInit(): void {
     setTimeout(() => {
-      this.initElements();
-      this.initStyles();
-      this.initEvents();
+      try {
+        this.initElements();
+        this.initStyles();
+        this.initEvents();
+      } catch (e) {
+        console.log('parallax needs more time to start - starting recursive launch attempts with delay 100ms');
+        this.ngAfterViewInit();
+      }
     }, 100);
   }
 


### PR DESCRIPTION
Required for native devices (which are a big target of ionic) since launch time is heavily affecting stability of this package.

Example: If this package attempts to initialize before some components of the user interface are loaded it will straight up crash and not attempt to reload later.

Tested on Android 10 with the result of 100% reliability of the parallax module.