### PR TITLE
Improve to select main content

### DIFF
--- a/projects/ionic-header-parallax/src/lib/ionic-header-parallax.directive.ts
+++ b/projects/ionic-header-parallax/src/lib/ionic-header-parallax.directive.ts
@@ -118,7 +118,7 @@ export class ParallaxDirective implements AfterContentInit {
   private setupContentPadding() {
     const parentElement = this.header.parentElement;
     const ionContent = parentElement.querySelector('ion-content');
-    const mainContent = ionContent.shadowRoot.querySelector('main');
+    const mainContent = ionContent.shadowRoot.querySelector('[part=scroll]');
     const { paddingTop } = window.getComputedStyle(mainContent);
     const contentPaddingPx = toPx(paddingTop);
     const coverHeightPx = this.getMaxHeightInPx();


### PR DESCRIPTION
Hi Rashid, 
after updating a project to Ionic 8, the directive stopped working.
I discovered that the problem originated [here](https://github.com/ionic-team/ionic-framework/blob/main/core/src/components/content/content.tsx#L461), when the Ionic team changed the `main` tag to a `div`. 
This issue can be solved by searching in the shadow root of the `ion-content` tag for the part `scroll`, which is the scrollable container of the content (official documentation can be found [here](https://ionicframework.com/docs/api/content#css-shadow-parts-1)).
This countermeasure ensures compatibility with previous version. 
Can you release an update version of the library?
Thanks in advance.